### PR TITLE
✨ 为 User 添加 global_name, avatar_decoration

### DIFF
--- a/nonebot/adapters/discord/api/model.py
+++ b/nonebot/adapters/discord/api/model.py
@@ -2218,6 +2218,7 @@ class User(BaseModel):
     id: Snowflake
     username: str
     discriminator: str
+    global_name: Optional[str]
     avatar: Optional[str] = Field(...)
     bot: Missing[bool] = UNSET
     system: Missing[bool] = UNSET
@@ -2230,6 +2231,7 @@ class User(BaseModel):
     flags: Missing[int] = UNSET
     premium_type: Missing[PremiumType] = UNSET
     public_flags: Missing[UserFlags] = UNSET
+    avatar_decoration: MissingOrNullable[str] = UNSET
 
 
 class Connection(BaseModel):


### PR DESCRIPTION
see https://discord.com/developers/docs/resources/user#user-object

<details>
<summary>Log</summary>

```python
04-14 15:45:47 [DEBUG] nonebot | Discord | Calling API get_user
04-14 15:45:48 [TRACE] nonebot | Discord | API code: 200 response: b'{"id":"474564749217234954","username":"autuamn_end","avatar":"7a8c1eacb63acfd711543f86244e5572","discriminator":"0","public_flags":0,"flags":0,"banner":null,"accent_color":null,"global_name":"Autuamn End","avatar_decoration_data":null,"banner_color":null,"clan":null}\n'
```

</details>

但是，在实际请求v10版的api时，返回的数据包为：
```json
{
    "id": "123123",
    "username": "xxx",
    "avatar": "123xxx",
    "discriminator": "0",
    "public_flags": 128,
    "flags": 128,
    "banner": null,
    "accent_color": 765631,
    "global_name": "xxxx",
    "avatar_decoration_data": {
        "asset": "a_5e1210779d99ece1c0b4f438a5bc6e72",
        "sku_id": "1216908559548289084"
    },
    "banner_color": "#0baebf",
    "clan": null
}
```
是否要添加 avatar_decoration_data