### PR TITLE
🐛 修复 event 文本获取错误 #19

### DIFF
--- a/nonebot/adapters/discord/message.py
+++ b/nonebot/adapters/discord/message.py
@@ -395,7 +395,7 @@ class Message(BaseMessage[MessageSegment]):
     def _construct(msg: str) -> Iterable[MessageSegment]:
         text_begin = 0
         for embed in re.finditer(
-            r"<(?P<type>(@!|@&|@|#|/|:|a:|t:))(?P<param>[^<]]+?)>",
+            r"<(?P<type>(@!|@&|@|#|/|:|a:|t:))(?P<param>[^<]+?)>",
             msg,
         ):
             if content := msg[text_begin : embed.pos + embed.start()]:

--- a/nonebot/adapters/discord/message.py
+++ b/nonebot/adapters/discord/message.py
@@ -36,7 +36,7 @@ from .api import (
     SnowflakeType,
     TimeStampStyle,
 )
-from .utils import escape, unescape
+from .utils import unescape
 
 
 class MessageSegment(BaseMessageSegment["Message"]):
@@ -319,7 +319,7 @@ class TextSegment(MessageSegment):
 
     @override
     def __str__(self) -> str:
-        return escape(self.data["text"])
+        return self.data["text"]
 
 
 class EmbedData(TypedDict):
@@ -395,7 +395,7 @@ class Message(BaseMessage[MessageSegment]):
     def _construct(msg: str) -> Iterable[MessageSegment]:
         text_begin = 0
         for embed in re.finditer(
-            r"<(?P<type>(@!|@&|@|#|/|:|a:|t:))?(?P<param>.+?)>",
+            r"<(?P<type>(@!|@&|@|#|/|:|a:|t:))(?P<param>[^<]]+?)>",
             msg,
         ):
             if content := msg[text_begin : embed.pos + embed.start()]:
@@ -436,7 +436,7 @@ class Message(BaseMessage[MessageSegment]):
         if message.mention_everyone:
             msg.append(MessageSegment.mention_everyone())
         if message.content:
-            msg.append(MessageSegment.text(message.content))
+            msg.extend(Message(message.content))
         if message.attachments:
             msg.extend(
                 MessageSegment.attachment(


### PR DESCRIPTION
对 `Message._construct` 的正则进一步修改，在 param 组匹配除了 `<` 之外的字符，以避免形如 `<@<@321321>` 的情况