### PR TITLE
修复 on_slash_command options 协变类型提示问题

### DIFF
--- a/nonebot/adapters/discord/commands/matcher.py
+++ b/nonebot/adapters/discord/commands/matcher.py
@@ -1,4 +1,4 @@
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from datetime import datetime, timedelta
 from typing import Any, Callable, Optional, Union
 
@@ -274,7 +274,7 @@ class UserMessageCommandMatcher(ApplicationCommandMatcher):
 def on_slash_command(  # noqa: PLR0913
     name: str,
     description: str,
-    options: Missing[list[AnyCommandOption]] = UNSET,
+    options: Missing[Sequence[AnyCommandOption]] = UNSET,
     internal_id: Optional[str] = None,
     rule: Union[Rule, T_RuleChecker, None] = None,
     permission: Union[Permission, T_PermissionChecker, None] = None,
@@ -299,7 +299,7 @@ def on_slash_command(  # noqa: PLR0913
         name_localizations=name_localizations,
         description=description,
         description_localizations=description_localizations,
-        options=options,
+        options=UNSET if is_unset(options) else list(options),
         default_member_permissions=default_member_permissions,
         dm_permission=dm_permission,
         default_permission=default_permission,


### PR DESCRIPTION
## Summary
- 将 `on_slash_command` 的 `options` 参数类型从 `Missing[list[AnyCommandOption]]` 调整为 `Missing[Sequence[AnyCommandOption]]`，允许 `list[StringOption]` 等协变场景通过类型检查
- 在函数内部将 `options` 统一转换回 `list`（保留 `UNSET` 语义），确保运行时行为与原先一致
- 修复 issue #28 中动态拼接 options 触发的 mypy/Pylance 报错

Closes #28