### PR TITLE
修复 guild 场景下 slash command get_user_id 上下文缺失

### DIFF
--- a/nonebot/adapters/discord/event.py
+++ b/nonebot/adapters/discord/event.py
@@ -752,10 +752,12 @@ class InteractionCreateEvent(NoticeEvent, InteractionCreate):
 
     @override
     def get_user_id(self) -> str:
-        if is_unset(self.user):
-            msg = "Event has no context!"
-            raise ValueError(msg)
-        return str(self.user.id)
+        if not is_unset(self.user):
+            return str(self.user.id)
+        if not is_unset(self.member) and not is_unset(self.member.user):
+            return str(self.member.user.id)
+        msg = "Event has no context!"
+        raise ValueError(msg)
 
 
 class PingInteractionEvent(InteractionCreateEvent):

--- a/tests/test_interaction_user_id.py
+++ b/tests/test_interaction_user_id.py
@@ -1,0 +1,72 @@
+from typing import Any
+
+from nonebot.adapters.discord.api import ApplicationCommandType
+from nonebot.adapters.discord.event import ApplicationCommandInteractionEvent
+
+from nonebot.compat import type_validate_python
+import pytest
+
+
+def _build_base_payload() -> dict[str, Any]:
+    return {
+        "id": 1,
+        "application_id": 2,
+        "type": 2,
+        "data": {
+            "id": 3,
+            "name": "issue23_repro",
+            "type": ApplicationCommandType.CHAT_INPUT,
+        },
+        "token": "token",
+        "version": 1,
+        "authorizing_integration_owners": {"0": "1"},
+    }
+
+
+def _build_user_payload() -> dict[str, Any]:
+    return {
+        "id": 516240373413183488,
+        "username": "scdhh",
+        "discriminator": "0",
+        "global_name": "scdhh",
+        "avatar": None,
+    }
+
+
+def _build_member_payload(*, include_user: bool) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "roles": [],
+        "joined_at": "2026-02-12T19:10:40.357000+00:00",
+        "flags": 0,
+    }
+    if include_user:
+        payload["user"] = _build_user_payload()
+    return payload
+
+
+def test_interaction_get_user_id_fallback_to_member_user() -> None:
+    payload = _build_base_payload()
+    payload["member"] = _build_member_payload(include_user=True)
+
+    event = type_validate_python(ApplicationCommandInteractionEvent, payload)
+
+    assert event.get_user_id() == "516240373413183488"
+
+
+def test_interaction_get_user_id_uses_top_level_user_in_dm() -> None:
+    payload = _build_base_payload()
+    payload["user"] = _build_user_payload()
+
+    event = type_validate_python(ApplicationCommandInteractionEvent, payload)
+
+    assert event.get_user_id() == "516240373413183488"
+
+
+def test_interaction_get_user_id_raises_without_user_context() -> None:
+    payload = _build_base_payload()
+    payload["member"] = _build_member_payload(include_user=False)
+
+    event = type_validate_python(ApplicationCommandInteractionEvent, payload)
+
+    with pytest.raises(ValueError, match="Event has no context!"):
+        event.get_user_id()


### PR DESCRIPTION
## Summary
- 修复 `InteractionCreateEvent.get_user_id` 在频道 slash command 场景下仅检查 `user` 导致报错的问题，新增回退到 `member.user.id`
- 保持 DM 场景优先读取顶层 `user`，并在 `user` 与 `member.user` 都缺失时继续抛出 `Event has no context!`
- 新增回归测试覆盖 guild 回退、DM 正常路径与缺失上下文报错三种情况

## Testing
- `uv run pytest -q tests/test_interaction_user_id.py`
- `uv run ruff check nonebot/adapters/discord/event.py tests/test_interaction_user_id.py`
- `uv run ruff format --check nonebot/adapters/discord/event.py tests/test_interaction_user_id.py`