### PR TITLE
🐛 修复 PayloadType 缺失 Heartbeat 类型

### DIFF
--- a/nonebot/adapters/discord/payload.py
+++ b/nonebot/adapters/discord/payload.py
@@ -74,7 +74,7 @@ class HeartbeatAck(Payload):
 
 PayloadType: TypeAlias = (
     Annotated[
-        Dispatch | Reconnect | InvalidSession | Hello | HeartbeatAck,
+        Dispatch | Heartbeat | Reconnect | InvalidSession | Hello | HeartbeatAck,
         Field(discriminator="opcode"),
     ]
     | Payload


### PR DESCRIPTION
## 问题

`PayloadType` 未包含 `Heartbeat` 类型，导致 `receive_payload()` 收到服务器发送的心跳请求时（`op=1`），无法正确反序列化为 `Heartbeat` 实例。

结果是 `_loop()` 中的 Heartbeat 分支永远不可达：
```python
elif isinstance(payload, Heartbeat):
    # 当接受到心跳payload时...
    await self._heartbeat(ws, bot)
```

## 修复

将 `Heartbeat` 添加到 `PayloadType` 的 Union 类型中。

```diff
 PayloadType: TypeAlias = (
     Annotated[
-        Dispatch | Reconnect | InvalidSession | Hello | HeartbeatAck,
+        Dispatch | Heartbeat | Reconnect | InvalidSession | Hello | HeartbeatAck,
         Field(discriminator="opcode"),
     ]
     | Payload
 )
```

## 验证

- [x] 运行 `ruff check` 通过
- [x] 运行 `ruff format --check` 通过
