### PR TITLE
🐛 修复 Gateway WebSocket 空闲超时重连

### DIFF
--- a/nonebot/adapters/discord/adapter.py
+++ b/nonebot/adapters/discord/adapter.py
@@ -184,7 +184,11 @@ class Adapter(BaseAdapter, HandleMixin):
             url=ws_url,
             headers=headers,
             params=params,
-            timeout=Timeout(read=None, close=10.0),
+            timeout=Timeout(
+                connect=self.discord_config.discord_api_timeout,
+                read=None,
+                close=10.0,
+            ),
             proxy=self.discord_config.discord_proxy,
         )
         heartbeat_task: asyncio.Task | None = None

--- a/nonebot/adapters/discord/adapter.py
+++ b/nonebot/adapters/discord/adapter.py
@@ -11,7 +11,7 @@ from typing_extensions import override
 from nonebot.adapters import Adapter as BaseAdapter, Bot as BaseBot
 
 from nonebot.compat import type_validate_json, type_validate_python
-from nonebot.drivers import URL, Driver, ForwardDriver, Request, WebSocket
+from nonebot.drivers import URL, Driver, ForwardDriver, Request, Timeout, WebSocket
 from nonebot.exception import WebSocketClosed
 from nonebot.plugin import get_plugin_config
 from nonebot.utils import escape_tag
@@ -184,6 +184,7 @@ class Adapter(BaseAdapter, HandleMixin):
             url=ws_url,
             headers=headers,
             params=params,
+            timeout=Timeout(read=None),
             proxy=self.discord_config.discord_proxy,
         )
         heartbeat_task: asyncio.Task | None = None

--- a/nonebot/adapters/discord/adapter.py
+++ b/nonebot/adapters/discord/adapter.py
@@ -184,7 +184,6 @@ class Adapter(BaseAdapter, HandleMixin):
             url=ws_url,
             headers=headers,
             params=params,
-            timeout=self.discord_config.discord_api_timeout,
             proxy=self.discord_config.discord_proxy,
         )
         heartbeat_task: asyncio.Task | None = None

--- a/nonebot/adapters/discord/adapter.py
+++ b/nonebot/adapters/discord/adapter.py
@@ -184,7 +184,7 @@ class Adapter(BaseAdapter, HandleMixin):
             url=ws_url,
             headers=headers,
             params=params,
-            timeout=Timeout(read=None),
+            timeout=Timeout(read=None, close=10.0),
             proxy=self.discord_config.discord_proxy,
         )
         heartbeat_task: asyncio.Task | None = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ license = "MIT"
 readme = "README.md"
 keywords = ["nonebot", "discord", "bot"]
 requires-python = ">=3.10,<4.0.0"
-dependencies = ["nonebot2>=2.4.4"]
+dependencies = ["nonebot2>=2.5.0"]
 
 [dependency-groups]
 dev = [

--- a/tests/test_outbound_transport_serialization.py
+++ b/tests/test_outbound_transport_serialization.py
@@ -342,5 +342,6 @@ async def test_gateway_websocket_request_does_not_inherit_api_timeout(
 
     assert captured_request is not None
     assert isinstance(captured_request.timeout, Timeout)
+    assert captured_request.timeout.connect == adapter.discord_config.discord_api_timeout
     assert captured_request.timeout.read is None
     assert captured_request.timeout.close == 10.0

--- a/tests/test_outbound_transport_serialization.py
+++ b/tests/test_outbound_transport_serialization.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Awaitable, Sequence
 from datetime import datetime, timezone
 import json
 from typing_extensions import override
 
-from nonebot.adapters.discord import adapter as adapter_module
 from nonebot.adapters.discord.api import handle
 from nonebot.adapters.discord.api.model import (
     AttachmentSend,
@@ -331,7 +331,7 @@ async def test_gateway_websocket_request_does_not_inherit_api_timeout(
 
     monkeypatch.setattr(adapter, "_get_bot_user", fake_get_bot_user)
     monkeypatch.setattr(adapter, "websocket", fake_websocket)
-    monkeypatch.setattr(adapter_module.asyncio, "sleep", stop_reconnect_sleep)
+    monkeypatch.setattr(asyncio, "sleep", stop_reconnect_sleep)
 
     with pytest.raises(StopForwardError):
         await adapter._forward_ws(  # noqa: SLF001

--- a/tests/test_outbound_transport_serialization.py
+++ b/tests/test_outbound_transport_serialization.py
@@ -342,6 +342,8 @@ async def test_gateway_websocket_request_does_not_inherit_api_timeout(
 
     assert captured_request is not None
     assert isinstance(captured_request.timeout, Timeout)
-    assert captured_request.timeout.connect == adapter.discord_config.discord_api_timeout
+    assert (
+        captured_request.timeout.connect == adapter.discord_config.discord_api_timeout
+    )
     assert captured_request.timeout.read is None
     assert captured_request.timeout.close == 10.0

--- a/tests/test_outbound_transport_serialization.py
+++ b/tests/test_outbound_transport_serialization.py
@@ -27,6 +27,7 @@ from nonebot.adapters.discord.config import BotInfo
 from tests.fake.doubles import DummyAdapter, DummyBot
 
 from nonebot.drivers import URL, Request, WebSocket
+from nonebot.utils import UNSET
 import pytest
 
 
@@ -341,4 +342,4 @@ async def test_gateway_websocket_request_does_not_inherit_api_timeout(
         )
 
     assert captured_request is not None
-    assert captured_request.timeout is None
+    assert captured_request.timeout is UNSET

--- a/tests/test_outbound_transport_serialization.py
+++ b/tests/test_outbound_transport_serialization.py
@@ -26,8 +26,7 @@ from nonebot.adapters.discord.api.types import (
 from nonebot.adapters.discord.config import BotInfo
 from tests.fake.doubles import DummyAdapter, DummyBot
 
-from nonebot.drivers import URL, Request, WebSocket
-from nonebot.utils import UNSET
+from nonebot.drivers import URL, Request, Timeout, WebSocket
 import pytest
 
 
@@ -342,4 +341,5 @@ async def test_gateway_websocket_request_does_not_inherit_api_timeout(
         )
 
     assert captured_request is not None
-    assert captured_request.timeout is UNSET
+    assert isinstance(captured_request.timeout, Timeout)
+    assert captured_request.timeout.read is None

--- a/tests/test_outbound_transport_serialization.py
+++ b/tests/test_outbound_transport_serialization.py
@@ -343,3 +343,4 @@ async def test_gateway_websocket_request_does_not_inherit_api_timeout(
     assert captured_request is not None
     assert isinstance(captured_request.timeout, Timeout)
     assert captured_request.timeout.read is None
+    assert captured_request.timeout.close == 10.0

--- a/tests/test_outbound_transport_serialization.py
+++ b/tests/test_outbound_transport_serialization.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 import json
 from typing_extensions import override
 
+from nonebot.adapters.discord import adapter as adapter_module
 from nonebot.adapters.discord.api import handle
 from nonebot.adapters.discord.api.model import (
     AttachmentSend,
@@ -14,6 +15,7 @@ from nonebot.adapters.discord.api.model import (
     InteractionResponse,
     RecurrenceRule,
     Snowflake,
+    User,
 )
 from nonebot.adapters.discord.api.types import (
     GuildScheduledEventEntityType,
@@ -21,9 +23,10 @@ from nonebot.adapters.discord.api.types import (
     GuildScheduledEventRecurrenceRuleFrequency,
     InteractionCallbackType,
 )
+from nonebot.adapters.discord.config import BotInfo
 from tests.fake.doubles import DummyAdapter, DummyBot
 
-from nonebot.drivers import Request, WebSocket
+from nonebot.drivers import URL, Request, WebSocket
 import pytest
 
 
@@ -283,3 +286,59 @@ async def test_gateway_heartbeat_uses_transport_json_text() -> None:
     await adapter._heartbeat(ws, bot)  # noqa: SLF001
 
     assert ws.sent == ['{"op":1,"d":42}']
+
+
+@pytest.mark.asyncio
+async def test_gateway_websocket_request_does_not_inherit_api_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = DummyAdapter()
+    adapter.discord_config.discord_api_timeout = 30.0
+    bot_info = BotInfo(token="x" * 10)
+    captured_request: Request | None = None
+
+    class StopForwardError(Exception):
+        pass
+
+    class StopWebSocket:
+        async def __aenter__(self) -> None:
+            msg = "websocket request captured"
+            raise RuntimeError(msg)
+
+        async def __aexit__(
+            self,
+            _exc_type: object,
+            _exc: object,
+            _traceback: object,
+        ) -> None:
+            return None
+
+    async def fake_get_bot_user(_bot_info: BotInfo) -> User:
+        return User(
+            id=Snowflake(1),
+            username="bot",
+            discriminator="0000",
+            avatar=None,
+        )
+
+    def fake_websocket(request: Request) -> StopWebSocket:
+        nonlocal captured_request
+        captured_request = request
+        return StopWebSocket()
+
+    async def stop_reconnect_sleep(_delay: float) -> None:
+        raise StopForwardError
+
+    monkeypatch.setattr(adapter, "_get_bot_user", fake_get_bot_user)
+    monkeypatch.setattr(adapter, "websocket", fake_websocket)
+    monkeypatch.setattr(adapter_module.asyncio, "sleep", stop_reconnect_sleep)
+
+    with pytest.raises(StopForwardError):
+        await adapter._forward_ws(  # noqa: SLF001
+            bot_info,
+            URL("wss://gateway.discord.gg"),
+            (0, 1),
+        )
+
+    assert captured_request is not None
+    assert captured_request.timeout is None

--- a/uv.lock
+++ b/uv.lock
@@ -516,7 +516,7 @@ wheels = [
 
 [[package]]
 name = "nonebot-adapter-discord"
-version = "1.1.6"
+version = "1.1.7"
 source = { editable = "." }
 dependencies = [
     { name = "nonebot2" },
@@ -548,7 +548,7 @@ test = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "nonebot2", specifier = ">=2.4.4" }]
+requires-dist = [{ name = "nonebot2", specifier = ">=2.5.0" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -577,7 +577,7 @@ test = [
 
 [[package]]
 name = "nonebot2"
-version = "2.4.4"
+version = "2.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -590,9 +590,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0a/85/d2201a11ec3c6e1ba4f663c61ff65a4da06becd3d66c3536c26694325361/nonebot2-2.4.4.tar.gz", hash = "sha256:b367c17f31ae0d548e374bb80b719ed12885620f29f3cbc305a5a88a6175f4e3", size = 90954, upload-time = "2025-10-29T04:02:55.577Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/9c/3c7b17e8bea5c929d748560bae2d79e68d8e1a6905384b00428ed0dd672f/nonebot2-2.5.0.tar.gz", hash = "sha256:5dca27d1d20d86bea823d2c3e0f5118f66af07788bc9d38f3e630bef36dfdf71", size = 91776, upload-time = "2026-04-01T03:33:46.512Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/66/ef/fa4a179d56f372619ce3899890277760b138ff6d5b395420e6d01e4523fd/nonebot2-2.4.4-py3-none-any.whl", hash = "sha256:8885d02906f1def83c138f298a7aa99ca1975351f44d8d290ea0eeec5aec1f0b", size = 118319, upload-time = "2025-10-29T04:02:54.55Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/4c/a8d2a4f4dab031965fc6ff9498cc76c2070c4a9989aee83509d4a551264a/nonebot2-2.5.0-py3-none-any.whl", hash = "sha256:12380d396a3d5126eeeae0a1aa53af45e9d99b63896e3e2dd6340ee436869e36", size = 119117, upload-time = "2026-04-01T03:33:47.728Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Fixes #92.

Discord Gateway WebSocket should not use the REST API timeout as a receive timeout. With NoneBot2 v2.5.0 + aiohttp, passing a scalar timeout maps to `ws_receive`, so the Gateway can reconnect after 30s of normal idle time.

This PR changes the Gateway WebSocket request to use an explicit structured timeout:

```py
Timeout(
    connect=discord_api_timeout,
    read=None,
    close=10.0,
)
```

That preserves bounded connect/close behavior while disabling only the receive timeout:

- aiohttp: `{'ws_receive': None, 'ws_close': 10.0}`
- websockets: `{'open_timeout': 30.0, 'close_timeout': 10.0}`

Also raises the minimum `nonebot2` dependency to `>=2.5.0` because the fix depends on the v2.5 `Timeout.close` field.

## Tests

- `uv run ruff check pyproject.toml nonebot/adapters/discord/adapter.py tests/test_outbound_transport_serialization.py`
- `uv run pytest tests/test_outbound_transport_serialization.py`
- `uv run pytest`
- Mapping check for NoneBot2 timeout conversion:
  - aiohttp `{'ws_receive': None, 'ws_close': 10.0}`
  - websockets `{'open_timeout': 30.0, 'close_timeout': 10.0}`
- Runtime constructor check:
  - `uv run --with 'aiohttp>=3.11,<4' --with 'websockets>=14,<16' python -c "import aiohttp; from websockets import connect; print(aiohttp.__version__); print(aiohttp.ClientWSTimeout(ws_receive=None, ws_close=10.0)); connect('wss://example.com', open_timeout=30.0, close_timeout=10.0); print('websockets connect accepted open_timeout=30.0 close_timeout=10.0')"`

Latest PR head: `13fe8e9d0cd088b162d41d00034f108bc5766ab5`; GitHub Actions `Pyright Lint` and `Code Coverage` passed.